### PR TITLE
update next c&c meeting time

### DIFF
--- a/code-coffee.html
+++ b/code-coffee.html
@@ -14,7 +14,7 @@ title: Code & Coffee
                 <h3>Monthly ASU Code and Coffee session for anyone who needs help with a coding-related problem.</h3>
                 <h4 style="padding-top: 20px">
                     Next meeting: <br>
-                    September 16, 2022, 11am-12pm MST
+                    September 23, 2022, 11am-12pm MST
                 </h4>
                 <p>
                     Please note that Code & Coffee sessions are now on Fridays at 11am MST!


### PR DESCRIPTION
are we still doing this on MST or Arizona time? Current time MST is 1 hr after Arizona time I believe..